### PR TITLE
Contracts: Rewrite factory and funding round contracts

### DIFF
--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -27,6 +27,8 @@ contract FundingRound is MACIPubKey {
   event FundsClaimed(address _recipient);
   event NewContribution(address indexed _sender, uint256 amount);
 
+  uint256 public counter;
+
   constructor(
     FundingRoundFactory _parent,
     IERC20 _nativeToken,
@@ -68,7 +70,7 @@ contract FundingRound is MACIPubKey {
     */
   function claimFunds(
     uint256 _poolShare,
-    uint256[][] memory _proof,
+    uint256[][] memory _proof
   )
     public
   {
@@ -90,6 +92,8 @@ contract FundingRound is MACIPubKey {
     PubKey memory pubKey,
     uint256 amount
   ) public {
+    require(address(maci) != address(0), 'FundingRound: MACI not deployed');
+    require(counter < maci.maxUsers(), 'FundingRound: Contributor limit reached');
     require(now < contributionDeadline, 'FundingRound: Contribution period ended');
     require(isFinalized == false, 'FundingRound: Round finalized');
     // TODO: check BrightID verification
@@ -101,6 +105,7 @@ contract FundingRound is MACIPubKey {
       signUpGatekeeperData,
       initialVoiceCreditProxyData
     );
+    counter += 1;
     emit NewContribution(msg.sender, amount);
   }
 

--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -27,6 +27,7 @@ contract FundingRound is MACIPubKey {
   event FundsClaimed(address _recipient);
   event NewContribution(address indexed _sender, uint256 amount);
 
+  mapping(address => uint256) public contributors;
   uint256 public counter;
 
   constructor(
@@ -95,7 +96,9 @@ contract FundingRound is MACIPubKey {
     require(address(maci) != address(0), 'FundingRound: MACI not deployed');
     require(counter < maci.maxUsers(), 'FundingRound: Contributor limit reached');
     require(now < contributionDeadline, 'FundingRound: Contribution period ended');
-    require(isFinalized == false, 'FundingRound: Round finalized');
+    require(!isFinalized, 'FundingRound: Round finalized');
+    require(amount > 0, 'FundingRound: Contribution amount must be greater than zero');
+    require(contributors[msg.sender] == 0, 'FundingRound: Already contributed');
     // TODO: check BrightID verification
     bytes memory signUpGatekeeperData = '';
     bytes memory initialVoiceCreditProxyData = abi.encode(amount);
@@ -105,6 +108,7 @@ contract FundingRound is MACIPubKey {
       signUpGatekeeperData,
       initialVoiceCreditProxyData
     );
+    contributors[msg.sender] = amount;
     counter += 1;
     emit NewContribution(msg.sender, amount);
   }

--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -114,12 +114,15 @@ contract FundingRound is MACIPubKey {
   }
 
   /**
-    * @dev Allow recipients to claim funds.
+    * @dev Allow recipients to claim funds after vote tally was done.
     */
   function finalize()
     public
     onlyFactory
   {
+    require(!isFinalized, 'FundingRound: Already finalized');
+    require(maci.calcVotingDeadline() < now, 'FundingRound: Voting has not been finished');
+    require(!maci.hasUntalliedStateLeaves(), 'FundingRound: Votes has not been tallied');
     isFinalized = true;
     poolSize = nativeToken.balanceOf(address(this));
   }

--- a/contracts/contracts/FundingRoundFactory.sol
+++ b/contracts/contracts/FundingRoundFactory.sol
@@ -18,9 +18,6 @@ import './FundingRound.sol';
 contract FundingRoundFactory is Ownable, MACIPubKey {
   using SafeERC20 for IERC20;
 
-  // Constants
-  uint256 private constant MACI_MAX_VOTE_OPTIONS = 625;
-
   // State
   mapping(address => string) public recipients;
   uint256 private recipientCount = 0;
@@ -75,7 +72,7 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
     require(_fundingAddress != address(0), 'Factory: Recipient address is zero');
     require(bytes(_name).length != 0, 'Factory: Recipient name is empty string');
     require(bytes(recipients[_fundingAddress]).length == 0, 'Factory: Recipient already registered');
-    require(recipientCount < MACI_MAX_VOTE_OPTIONS, 'Factory: Recipient limit reached');
+    require(recipientCount < maciFactory.maxVoteOptions(), 'Factory: Recipient limit reached');
     recipients[_fundingAddress] = _name;
     recipientCount += 1;
     emit RecipientAdded(_fundingAddress, _name);
@@ -93,17 +90,36 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
     return previousRound;
   }
 
-  function deployMaci(
+  function setMaciParameters(
+    uint8 _stateTreeDepth,
+    uint8 _messageTreeDepth,
+    uint8 _voteOptionTreeDepth,
+    uint8 _tallyBatchSize,
+    uint8 _messageBatchSize,
     uint256 _signUpDuration,
-    uint256 _votingDuration,
+    uint256 _votingDuration
+  )
+    public
+    onlyOwner
+  {
+    maciFactory.setMaciParameters(
+      _stateTreeDepth,
+      _messageTreeDepth,
+      _voteOptionTreeDepth,
+      _tallyBatchSize,
+      _messageBatchSize,
+      _signUpDuration,
+      _votingDuration
+    );
+  }
+
+  function deployMaci(
     PubKey memory _coordinatorPubKey
   )
     public
     onlyOwner
   {
     maciFactory.deployMaci(
-      _signUpDuration,
-      _votingDuration,
       _coordinatorPubKey
     );
   }

--- a/contracts/contracts/FundingRoundFactory.sol
+++ b/contracts/contracts/FundingRoundFactory.sol
@@ -91,6 +91,11 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
     public
     onlyOwner
   {
+    FundingRound currentRound = getCurrentRound();
+    require(
+      address(currentRound) == address(0) || address(currentRound.maci()) != address(0),
+      'Factory: Waiting for MACI deployment'
+    );
     maciFactory.setMaciParameters(
       _stateTreeDepth,
       _messageTreeDepth,

--- a/contracts/contracts/InitialVoiceCreditProxy.sol
+++ b/contracts/contracts/InitialVoiceCreditProxy.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.5.0;
+
+import 'maci/contracts/sol/initialVoiceCreditProxy/InitialVoiceCreditProxy.sol';
+
+contract FundingRoundVoiceCreditProxy is InitialVoiceCreditProxy {
+  function getVoiceCredits(
+    address _user,
+    bytes memory _data
+  )
+    public
+    view
+    returns (uint256)
+  {
+    uint256 initialVoiceCredit = abi.decode(_data, (uint256));
+    return initialVoiceCredit;
+  }
+}

--- a/contracts/contracts/MACIFactory.sol
+++ b/contracts/contracts/MACIFactory.sol
@@ -5,9 +5,10 @@ import '@openzeppelin/contracts/ownership/Ownable.sol';
 import 'maci/contracts/sol/MACI.sol';
 import 'maci/contracts/sol/MACIParameters.sol';
 import 'maci/contracts/sol/gatekeepers/FreeForAllSignUpGatekeeper.sol';
-import 'maci/contracts/sol/initialVoiceCreditProxy/ConstantInitialVoiceCreditProxy.sol';
 import { BatchUpdateStateTreeVerifier } from 'maci/contracts/sol/BatchUpdateStateTreeVerifier.sol';
 import { QuadVoteTallyVerifier } from 'maci/contracts/sol/QuadVoteTallyVerifier.sol';
+
+import './InitialVoiceCreditProxy.sol';
 
 contract MACIFactory is Ownable, MACIParameters {
   // Constants
@@ -30,7 +31,7 @@ contract MACIFactory is Ownable, MACIParameters {
   FreeForAllGatekeeper private signUpGatekeeper;
   BatchUpdateStateTreeVerifier private batchUstVerifier;
   QuadVoteTallyVerifier private qvtVerifier;
-  ConstantInitialVoiceCreditProxy private initialVoiceCreditProxy;
+  FundingRoundVoiceCreditProxy private initialVoiceCreditProxy;
 
   // Events
   event MaciParametersChanged();
@@ -40,7 +41,7 @@ contract MACIFactory is Ownable, MACIParameters {
     FreeForAllGatekeeper _signUpGatekeeper,
     BatchUpdateStateTreeVerifier _batchUstVerifier,
     QuadVoteTallyVerifier _qvtVerifier,
-    ConstantInitialVoiceCreditProxy _initialVoiceCreditProxy
+    FundingRoundVoiceCreditProxy _initialVoiceCreditProxy
   )
     public
   {

--- a/contracts/scripts/deploy.ts
+++ b/contracts/scripts/deploy.ts
@@ -21,7 +21,6 @@ async function main() {
   }
   const fundingRoundFactory = await FundingRoundFactory.deploy(
     maciFactory.address,
-    firstCoordinator,
   );
 
   // The address that the Contract WILL have once mined

--- a/contracts/scripts/helpers.ts
+++ b/contracts/scripts/helpers.ts
@@ -32,7 +32,7 @@ export async function deployMaciFactory(account: Signer): Promise<Contract> {
   const signUpGatekeeper = await deployContract(account, 'FreeForAllGatekeeper');
   const batchTreeVerifier = await deployContract(account, 'BatchUpdateStateTreeVerifier');
   const voteTallyVerifier = await deployContract(account, 'QuadVoteTallyVerifier');
-  const initialVoiceCreditProxy = await deployContract(account, 'ConstantInitialVoiceCreditProxy', [0]);
+  const initialVoiceCreditProxy = await deployContract(account, 'FundingRoundVoiceCreditProxy');
   const poseidonT3 = await deployContract(account, 'PoseidonT3');
   const poseidonT6 = await deployContract(account, 'PoseidonT6');
 

--- a/contracts/tests/factory.ts
+++ b/contracts/tests/factory.ts
@@ -4,7 +4,7 @@ import { deployContract, solidity } from 'ethereum-waffle';
 import { ethers } from 'ethers';
 
 import { deployMaciFactory } from '../scripts/helpers';
-import { getGasUsage } from './utils';
+import { getGasUsage, MaciParameters } from './utils';
 
 import RoundArtifact from '../build/contracts/FundingRound.json';
 import FactoryArtifact from '../build/contracts/FundingRoundFactory.json';
@@ -21,12 +21,15 @@ describe('Funding Round Factory', () => {
 
   const [dontUseMe, deployer, coordinator, contributor] = provider.getWallets();
 
+  let maciFactory: ethers.Contract;
   let factory: ethers.Contract;
   let token;
   let tokenContractAsContributor;
 
+  let maciParameters = new MaciParameters();
+
   beforeEach(async () => {
-    const maciFactory = await deployMaciFactory(deployer);
+    maciFactory = await deployMaciFactory(deployer);
 
     factory = await deployContract(deployer, FactoryArtifact, [
       maciFactory.address,
@@ -101,7 +104,11 @@ describe('Funding Round Factory', () => {
     });
 
     it('should limit the number of recipients', async () => {
-      const maxRecipientCount = 625;
+      // Reduce number of vote options to speed up the test
+      maciParameters = new MaciParameters({ voteOptionTreeDepth: 1 });
+      await factory.setMaciParameters(...maciParameters.values());
+
+      const maxRecipientCount = 4;
       for (var i = 0; i < maxRecipientCount + 1; i++) {
         recipientName = String(i + 1).padStart(4, '0');
         fundingAddress = `0x000000000000000000000000000000000000${recipientName}`;
@@ -115,14 +122,21 @@ describe('Funding Round Factory', () => {
     });
   });
 
+  it('sets MACI parameters', async () => {
+    await expect(factory.setMaciParameters(...maciParameters.values()))
+      .to.emit(maciFactory, 'MaciParametersChanged');
+  });
+
+  it('allows only owner to set MACI parameters', async () => {
+    const coordinatorFactory = factory.connect(coordinator);
+    await expect(coordinatorFactory.setMaciParameters(...maciParameters.values()))
+      .to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
   it('deploys MACI', async () => {
-    const signUpDuration = 86400;
-    const votingDuration = 86400;
     const coordinatorPubKey = { x: 0, y: 1 };
 
     const deployTx = await factory.deployMaci(
-      signUpDuration,
-      votingDuration,
       coordinatorPubKey,
     );
     expect(await getGasUsage(deployTx)).lessThan(7000000);

--- a/contracts/tests/factory.ts
+++ b/contracts/tests/factory.ts
@@ -33,7 +33,6 @@ describe('Funding Round Factory', () => {
 
     factory = await deployContract(deployer, FactoryArtifact, [
       maciFactory.address,
-      coordinator.address,
     ]);
 
     expect(factory.address).to.properAddress;
@@ -135,23 +134,31 @@ describe('Funding Round Factory', () => {
 
   it('deploys MACI', async () => {
     const coordinatorPubKey = { x: 0, y: 1 };
-
-    const deployTx = await factory.deployMaci(
+    await factory.setCoordinator(
+      coordinator.address,
       coordinatorPubKey,
     );
+    await factory.deployNewRound();
+
+    const deployTx = await factory.deployMaci();
     expect(await getGasUsage(deployTx)).lessThan(7000000);
   });
 
   it('has new round running', async () => {
-    expect(await factory.currentRound()).to.properAddress;
+    expect(await factory.getCurrentRound()).to.properAddress;
   });
 
   it('set contract owner/witness/coordinator/round duration correctly', async () => {
+    const coordinatorPubKey = { x: 0, y: 1 };
+    await factory.setCoordinator(
+      coordinator.address,
+      coordinatorPubKey,
+    );
     expect(await factory.coordinator()).to.eq(coordinator.address);
   });
 
   it('allows user to contribute to current round', async () => {
-    const contractAddress = await factory.currentRound();
+    const contractAddress = await factory.getCurrentRound();
     console.log('About to build contract');
     console.log({ contractAddress });
 

--- a/contracts/tests/utils.ts
+++ b/contracts/tests/utils.ts
@@ -9,3 +9,34 @@ export async function getGasUsage(transaction: TransactionResponse): Promise<Num
     return null;
   }
 }
+
+export class MaciParameters {
+
+  // Defaults for tests
+  stateTreeDepth = 4;
+  messageTreeDepth = 4;
+  voteOptionTreeDepth = 2;
+  tallyBatchSize = 2;
+  messageBatchSize = 2;
+  signUpDuration = 3600;
+  votingDuration = 3600;
+
+  constructor(parameters: {[name: string]: number} = {}) {
+    for (const [name, value] of Object.entries(parameters)) {
+      (this as any)[name] = value;
+    }
+  }
+
+  values(): number[] {
+    // To be passed to setMaciParameters()
+    return [
+      this.stateTreeDepth,
+      this.messageTreeDepth,
+      this.voteOptionTreeDepth,
+      this.tallyBatchSize,
+      this.messageBatchSize,
+      this.signUpDuration,
+      this.votingDuration,
+    ];
+  }
+}


### PR DESCRIPTION
In this PR I'm implementing the scheme described in this diagram: https://github.com/clrfund/monorepo/issues/14#issuecomment-638685294.

- Factory contract now stores the history of all rounds, not just the current round and the one before it.
- Added method for making contributions to the matching pool: `FundingRoundFactory.contribute()`.
- The assumption here is that MACI deployment happens at the beginning of the round. But we can change that.
- Finalization of a funding round doesn't trigger deployment of a new round.
- All code related to funding round cancellation were temporarily removed. The plan is to re-implement it separately from this PR: https://github.com/clrfund/monorepo/issues/46.
- Implemented https://github.com/clrfund/monorepo/issues/18. Witness role were removed.
- Claiming of funds will be implemented later (https://github.com/clrfund/monorepo/issues/19).
- Implemented https://github.com/clrfund/monorepo/issues/27. There's no BrightID verification at the moment, everyone can contribute.
